### PR TITLE
BatteryRemoveFailedEvent

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
     'label' => 'taoBattery extension',
     'description' => 'An extension to assign test-takers to a battery of deliveries instead of one delivery',
     'license' => 'GPL-2.0',
-    'version' => '0.6.2',
+    'version' => '0.6.3',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=21.15.0',

--- a/model/event/BatteryRemoveFailedEvent.php
+++ b/model/event/BatteryRemoveFailedEvent.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\taoBattery\model\event;
+
+/**
+ * Triggered after BatteryBeforeRemoveEvent in case of removing error,
+ * to inform events consumer that BatteryRemovedEvent will not be triggered
+ *
+ * Subscribers are expected not to throw exceptions during event handling
+ */
+class BatteryRemoveFailedEvent extends AbstractBatteryEvent
+{
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -63,7 +63,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('0.1.0');
         }
 
-        $this->skip('0.1.0', '0.6.2');
+        $this->skip('0.1.0', '0.6.3');
     }
 
 }


### PR DESCRIPTION
blocks https://github.com/oat-sa/extension-tao-nccer-delivery/pull/790

`BatteryRemoveFailedEvent` allows subscribers to be aware of removing error and handle it in a proper way. Getting `BatteryRemoveFailedEvent` they are able to know that they shouldn't wait for `BatteryRemovedEvent`