### PR TITLE
A battery's delivery list changes should be logged

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'label' => 'taoBattery extension',
     'description' => 'An extension to assign test-takers to a battery of deliveries instead of one delivery',
     'license' => 'GPL-2.0',
-    'version' => '0.6.5',
+    'version' => '0.6.6',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=21.15.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -83,7 +83,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('0.6.4');
         }
 
-        $this->skip('0.6.4', '0.6.5');
+        $this->skip('0.6.4', '0.6.6');
     }
 
 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-8003

One more logger call to cover the case of added or removed delivery.

Plus, using `returnJson` instead of `echo json_encode`.