### PR TITLE
'success' field in json response

### DIFF
--- a/controller/Battery.php
+++ b/controller/Battery.php
@@ -91,13 +91,14 @@ class Battery extends \tao_actions_RdfController
         $item = $this->getClassService()->createInstance($clazz, $label);
         $this->getEventManager()->trigger(new BatteryCreatedEvent($item, [$label]));
 
-        if(! is_null($item)){
+        if(!is_null($item)) {
             $response = array(
                 'label'	=> $item->getLabel(),
-                'uri' 	=> $item->getUri()
+                'uri' 	=> $item->getUri(),
+                'success' 	=> true,
             );
         } else {
-            $response = false;
+            $response = ['success' => false];
         }
 
         $this->returnJson($response);

--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'label' => 'taoBattery extension',
     'description' => 'An extension to assign test-takers to a battery of deliveries instead of one delivery',
     'license' => 'GPL-2.0',
-    'version' => '0.6.6',
+    'version' => '0.6.7',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=21.15.0',

--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'label' => 'taoBattery extension',
     'description' => 'An extension to assign test-takers to a battery of deliveries instead of one delivery',
     'license' => 'GPL-2.0',
-    'version' => '0.6.5',
+    'version' => '0.6.6',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=21.15.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -83,7 +83,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('0.6.4');
         }
 
-        $this->skip('0.6.4', '0.6.6');
+        $this->skip('0.6.4', '0.6.7');
     }
 
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -83,7 +83,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('0.6.4');
         }
 
-        $this->skip('0.6.4', '0.6.5');
+        $this->skip('0.6.4', '0.6.6');
     }
 
 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-8314

'Success' field added to the JSON response to prevent the following FE error:
 'The server has sent an empty response'.